### PR TITLE
Dev

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,7 +1,5 @@
 # API Reference
 
-The quick brown fox flew too close to the sun.
-
 ```{toctree}
 :hidden:
 

--- a/inferno/__init__.py
+++ b/inferno/__init__.py
@@ -32,6 +32,7 @@ from .core import (
     trace_cumulative,
     trace_nearest_scaled,
     trace_cumulative_scaled,
+    trace_cumulative_value,
 )
 
 __all__ = [
@@ -66,4 +67,5 @@ __all__ = [
     "trace_cumulative",
     "trace_nearest_scaled",
     "trace_cumulative_scaled",
+    "trace_cumulative_value",
 ]

--- a/inferno/core/__init__.py
+++ b/inferno/core/__init__.py
@@ -33,6 +33,7 @@ from .trace import (
     trace_cumulative,
     trace_nearest_scaled,
     trace_cumulative_scaled,
+    trace_cumulative_value,
 )
 
 __all__ = [
@@ -69,4 +70,5 @@ __all__ = [
     "trace_cumulative",
     "trace_nearest_scaled",
     "trace_cumulative_scaled",
+    "trace_cumulative_value",
 ]

--- a/inferno/core/trace.py
+++ b/inferno/core/trace.py
@@ -164,13 +164,6 @@ def trace_cumulative_scaled(
     the trace value, in addition to the additive component.
 
     .. math::
-        x_{t + \Delta t} =
-        \begin{cases}
-            a + Sf + x_t \exp (\Delta t / \tau) &K(f_{t + \Delta t}) \\
-            x_t \exp (\Delta t / \tau) &\text{otherwise}
-        \end{cases}
-
-    .. math::
         x(t) = x(t - \Delta t) \exp \left(-\frac{\Delta t}{\tau_x}\right)
         + (sh + A) \left[\lvert J(h) \right]
 
@@ -202,3 +195,35 @@ def trace_cumulative_scaled(
         return (scale * observation + amplitude) * mask
     else:
         return (decay * trace) + (scale * observation + amplitude) * mask
+
+
+def trace_cumulative_value(
+    observation: torch.Tensor,
+    trace: torch.Tensor | None,
+    *,
+    decay: float | torch.Tensor,
+    scale: int | float | complex | torch.Tensor,
+) -> torch.Tensor:
+    r"""Performs a trace for a time step, considering all prior values.
+
+    .. math::
+        x(t) = x(t - \Delta t) \exp \left(-\frac{\Delta t}{\tau_x}\right)
+        + sh
+
+    Args:
+        observation (torch.Tensor): latest state to consider for the trace, :math:`h`.
+        trace (torch.Tensor | None): current value of the trace, :math:`x`,
+            if not the inital condition.
+        decay (float | torch.Tensor): exponential decay for adaptations,
+            :math:`\exp\left(-\frac{\Delta t}{\tau_x}\right)`, unitless.
+        scale (int | float | complex | torch.Tensor): value to multiply inputs by for
+            the trace, :math:`s`.
+
+    Returns:
+        torch.Tensor: updated trace, incorporating the new observation.
+    """
+    # compute new state
+    if trace is None:
+        return scale * observation
+    else:
+        return (decay * trace) + (scale * observation)

--- a/inferno/neural/base.py
+++ b/inferno/neural/base.py
@@ -1167,11 +1167,11 @@ class Connection(Updatable, Module, ABC):
             ``return``:
 
             :math:`B \times` `broadcastable <https://pytorch.org/docs/stable/notes/broadcasting.html>`_
-            with :py:attr:`weight` :math:`\times L`
+            with :py:attr:`weight` :math:`\times L\cdot`
 
             Where:
                 * :math:`B` is the batch size.
-                * :math:`L` is a connection-dependent value.
+                * :math:`L\cdot` is a connection-dependent value.
         """
         raise NotImplementedError(
             f"{type(self).__name__}(Connection) must implement "
@@ -1202,11 +1202,11 @@ class Connection(Updatable, Module, ABC):
             ``return``:
 
             :math:`B \times` `broadcastable <https://pytorch.org/docs/stable/notes/broadcasting.html>`_
-            with :py:attr:`weight` :math:`\times L`
+            with :py:attr:`weight` :math:`\times L\cdot`
 
             Where:
                 * :math:`B` is the batch size.
-                * :math:`L` is a connection-dependent value.
+                * :math:`L\cdot` is a connection-dependent value.
         """
         raise NotImplementedError(
             f"{type(self).__name__}(Connection) must implement "

--- a/test/learn/test_supervised_stdp.py
+++ b/test/learn/test_supervised_stdp.py
@@ -228,7 +228,6 @@ class TestMSTDPET:
         base_tc_eligibility = random.uniform(15.0, 30.0)
         base_interp_tolerance = random.uniform(1e-7, 1e-5)
         base_batch_reduction = torch.amax
-        base_field_reduction = torch.mean
 
         override_step_time = random.uniform(0.7, 1.4)
         override_lr_post = random.uniform(-1.0, 1.0)
@@ -238,7 +237,6 @@ class TestMSTDPET:
         override_tc_eligibility = random.uniform(15.0, 30.0)
         override_interp_tolerance = random.uniform(1e-7, 1e-5)
         override_batch_reduction = torch.amin
-        override_field_reduction = torch.sum
 
         updater = MSTDPET(
             step_time=base_step_time,
@@ -249,7 +247,6 @@ class TestMSTDPET:
             tc_eligibility=base_tc_eligibility,
             interp_tolerance=base_interp_tolerance,
             batch_reduction=base_batch_reduction,
-            field_reduction=base_field_reduction,
         )
 
         unit = updater.register_cell(
@@ -263,7 +260,6 @@ class TestMSTDPET:
             tc_eligibility=override_tc_eligibility,
             interp_tolerance=override_interp_tolerance,
             batch_reduction=override_batch_reduction,
-            field_reduction=override_field_reduction,
         )
 
         assert override_step_time == unit.state.step_time
@@ -274,7 +270,6 @@ class TestMSTDPET:
         assert override_tc_eligibility == unit.state.tc_eligibility
         assert override_interp_tolerance == unit.state.tolerance
         assert override_batch_reduction == unit.state.batchreduce
-        assert override_field_reduction == unit.state.fieldreduce
 
     def test_default_passthrough(self):
         shape = randshape(1, 3, 3, 5)
@@ -292,7 +287,6 @@ class TestMSTDPET:
         base_tc_eligibility = random.uniform(15.0, 30.0)
         base_interp_tolerance = random.uniform(1e-7, 1e-5)
         base_batch_reduction = torch.amax
-        base_field_reduction = torch.mean
 
         updater = MSTDPET(
             step_time=base_step_time,
@@ -303,7 +297,6 @@ class TestMSTDPET:
             tc_eligibility=base_tc_eligibility,
             interp_tolerance=base_interp_tolerance,
             batch_reduction=base_batch_reduction,
-            field_reduction=base_field_reduction,
         )
 
         unit = updater.register_cell("onlyone", layer.cell)
@@ -316,7 +309,6 @@ class TestMSTDPET:
         assert base_tc_eligibility == unit.state.tc_eligibility
         assert base_interp_tolerance == unit.state.tolerance
         assert base_batch_reduction == unit.state.batchreduce
-        assert base_field_reduction == unit.state.fieldreduce
 
     @pytest.mark.parametrize(
         "kind",
@@ -358,7 +350,6 @@ class TestMSTDPET:
         tc_eligibility = random.uniform(15.0, 30.0)
         interp_tolerance = random.uniform(1e-7, 1e-5)
         batch_reduction = torch.sum
-        field_reduction = torch.sum
 
         updater = MSTDPET(
             step_time=step_time,
@@ -369,7 +360,6 @@ class TestMSTDPET:
             tc_eligibility=tc_eligibility,
             interp_tolerance=interp_tolerance,
             batch_reduction=batch_reduction,
-            field_reduction=field_reduction,
         )
 
         _ = updater.register_cell("onlyone", layer.cell)

--- a/test/learn/test_unsupervised_stdp.py
+++ b/test/learn/test_unsupervised_stdp.py
@@ -124,7 +124,6 @@ class TestSTDP:
         base_interp_tolerance = random.uniform(1e-7, 1e-5)
         base_trace_mode = "nearest"
         base_batch_reduction = torch.amax
-        base_field_reduction = torch.mean
 
         override_step_time = random.uniform(0.7, 1.4)
         override_lr_post = random.uniform(-1.0, 1.0)
@@ -135,7 +134,6 @@ class TestSTDP:
         override_interp_tolerance = random.uniform(1e-7, 1e-5)
         override_trace_mode = "cumulative"
         override_batch_reduction = torch.amin
-        override_field_reduction = torch.sum
 
         layer = mocklayer(shape, batchsz, dt, delay)
         updater = STDP(
@@ -148,7 +146,6 @@ class TestSTDP:
             interp_tolerance=base_interp_tolerance,
             trace_mode=base_trace_mode,
             batch_reduction=base_batch_reduction,
-            field_reduction=base_field_reduction,
         )
 
         unit = updater.register_cell(
@@ -163,7 +160,6 @@ class TestSTDP:
             interp_tolerance=override_interp_tolerance,
             trace_mode=override_trace_mode,
             batch_reduction=override_batch_reduction,
-            field_reduction=override_field_reduction,
         )
 
         assert override_step_time == unit.state.step_time
@@ -175,7 +171,6 @@ class TestSTDP:
         assert override_interp_tolerance == unit.state.tolerance
         assert override_trace_mode == unit.state.tracemode
         assert override_batch_reduction == unit.state.batchreduce
-        assert override_field_reduction == unit.state.fieldreduce
 
     def test_default_passthrough(self):
         shape = randshape(1, 3, 3, 5)
@@ -192,7 +187,6 @@ class TestSTDP:
         base_interp_tolerance = random.uniform(1e-7, 1e-5)
         base_trace_mode = "nearest"
         base_batch_reduction = torch.amax
-        base_field_reduction = torch.mean
 
         layer = mocklayer(shape, batchsz, dt, delay)
         updater = STDP(
@@ -205,7 +199,6 @@ class TestSTDP:
             interp_tolerance=base_interp_tolerance,
             trace_mode=base_trace_mode,
             batch_reduction=base_batch_reduction,
-            field_reduction=base_field_reduction,
         )
 
         unit = updater.register_cell("onlyone", layer.cell)
@@ -219,7 +212,6 @@ class TestSTDP:
         assert base_interp_tolerance == unit.state.tolerance
         assert base_trace_mode == unit.state.tracemode
         assert base_batch_reduction == unit.state.batchreduce
-        assert base_field_reduction == unit.state.fieldreduce
 
     @pytest.mark.parametrize(
         "mode",
@@ -269,7 +261,6 @@ class TestSTDP:
             interp_tolerance=interp_tolerance,
             trace_mode=trace_mode,
             batch_reduction=batch_reduction,
-            field_reduction=field_reduction,
         )
         unit = updater.register_cell("onlyone", layer.cell)
 
@@ -449,7 +440,6 @@ class TestSTDP:
         interp_tolerance = 1e-3
         trace_mode = "cumulative"
         batch_reduction = torch.sum
-        field_reduction = torch.sum
 
         updater = STDP(
             step_time=step_time,
@@ -461,7 +451,6 @@ class TestSTDP:
             interp_tolerance=interp_tolerance,
             trace_mode=trace_mode,
             batch_reduction=batch_reduction,
-            field_reduction=field_reduction,
         )
         _ = updater.register_cell("onlyone", layer.cell)
 


### PR DESCRIPTION
Merging changes from "einsum" feature branch.

Elementwise operations in ``STDP`` and ``MSTDPET`` have been replaced with ``einops.einsum`` operations. On CPU a performance improvement of ~1.5x has been observed.

Minor changes include rephrasing the ``einops.rearrange`` operations in ``presyn_receptive`` and ``postsyn_receptive`` to remove the need for a conditional statement and adding ``trace_cumulative_value`` which acts like ``trace_cumulative_scaled`` if the condition is always true (this is used by ``MSTDPET`` but will most likely be used elsewhere too).